### PR TITLE
Fix typo: 'treshold' to 'threshold'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ var remoteFn = function () {
 };
 
 var circuitBreaker = new CircuitBreaker(remoteFn, {
-  failureTreshold: 3 // Default "5"
+  failureThreshold: 3 // Default "5"
 });
 
 circuitBreaker.fire().done(function () {

--- a/jquery.circuitbreaker.js
+++ b/jquery.circuitbreaker.js
@@ -19,7 +19,7 @@ var CircuitBreaker = function (asyncFn, options) {
   this.failures = 0;
 
   this.options = $.extend({
-    failureTreshold: 5
+    failureThreshold: 5
   }, options);
 };
 
@@ -53,7 +53,7 @@ CircuitBreaker.prototype.getState = function () {
 };
 
 CircuitBreaker.prototype.getFailureThreshold = function () {
-  return this.options.failureTreshold;
+  return this.options.failureThreshold;
 };
 
 var CircuitBreakerError = function () {};


### PR DESCRIPTION
There is a typo in a word threshold. In some places it is spelled correctly as 'threshold'. In several other places it is spelled incorrectly as 'treshold'. This PR makes sure word is spelled correctly everywhere.